### PR TITLE
fix: Remove 'unstable API' message from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Java 7 or above is required for using this client.
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version zero (`0.y.z`), which means that anything may change at any time
-and the public API should not be considered stable.
-
 ## Contributing
 
 Contributions to this library are always welcome and highly encouraged.


### PR DESCRIPTION
We've been >v1 for two years.